### PR TITLE
implement netcat like 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 _build
 .merlin
+.vscode

--- a/lib/connection.ml
+++ b/lib/connection.ml
@@ -1,1 +1,69 @@
-type t = unit
+open Dispatch
+
+type t
+
+external network_connection_create : Endpoint.t -> Parameters.t -> t
+  = "ocaml_network_connection_create"
+
+external network_connection_set_queue : Queue.t -> t -> unit
+  = "ocaml_network_connection_set_queue"
+
+external network_connection_retain : t -> unit
+  = "ocaml_network_connection_retain"
+
+external network_connection_start : t -> unit = "ocaml_network_connection_start"
+
+external network_connection_cancel : t -> unit
+  = "ocaml_network_connection_cancel"
+
+let create ~params endpoint = network_connection_create endpoint params
+
+let set_queue ~queue t = network_connection_set_queue queue t
+
+let retain t = network_connection_retain t
+
+let start t = network_connection_start t
+
+let cancel t = network_connection_cancel t
+
+module State = struct
+  type t = Invalid | Waiting | Preparing | Ready | Failed | Cancelled
+
+  type handler = t -> Error.t -> unit
+end
+
+external network_connection_set_state_changed_handler :
+  State.handler -> t -> unit
+  = "ocaml_network_connection_set_state_changed_handler"
+
+let set_state_changed_handler ~handler t =
+  network_connection_set_state_changed_handler handler t
+
+module Context = struct
+  type t = unit
+
+  let default () = ()
+
+  let retain _ = ()
+
+  let release _ = ()
+end
+
+type receive_completion =
+  Dispatch.Data.t -> Context.t -> bool -> Error.t -> unit
+
+external network_connection_receive :
+  int -> int -> receive_completion -> t -> unit
+  = "ocaml_network_connection_receive"
+
+let receive ~min ~max ~completion t =
+  network_connection_receive min max completion t
+
+type send_completion = Error.t -> unit
+
+external network_connection_send :
+  Dispatch.Data.t -> Context.t -> bool -> send_completion -> t -> unit
+  = "ocaml_network_connection_send"
+
+let send ~is_complete ~completion ~context ~data t =
+  network_connection_send data context is_complete completion t

--- a/lib/endpoint.ml
+++ b/lib/endpoint.ml
@@ -2,7 +2,17 @@ module Type = struct
   type t = Invalid | Address | Host | Bonjour | Url
 end
 
-type t = unit
+type t
 (** The type for endpoints *)
+
+external network_endpoint_create_host : string -> string -> t
+  = "ocaml_network_endpoint_create_host"
+
+external network_endpoint_release : t -> unit = "ocaml_network_endpoint_release"
+
+let create_host ~hostname port =
+  network_endpoint_create_host hostname (string_of_int port)
+
+let release t = network_endpoint_release t
 
 let get_type _ = Type.Invalid

--- a/lib/endpoint.mli
+++ b/lib/endpoint.mli
@@ -10,5 +10,11 @@ end
 type t
 (** The type for endpoints *)
 
+val create_host : hostname:string -> int -> t
+(** [create_host ~hostname port] will create a network endpoint with a
+    [hostname] and a [port], the [hostname] can be interpretted as an IP address *)
+
+val release : t -> unit
+
 val get_type : t -> Type.t
 (** [get_type t] returns the type of the endpoint *)

--- a/lib/listener.ml
+++ b/lib/listener.ml
@@ -10,6 +10,15 @@ external network_listener_create_with_connection :
   Connection.t -> Parameters.t -> t
   = "ocaml_network_listener_create_with_connection"
 
+external network_listener_get_port : t -> int
+  = "ocaml_network_listener_get_port"
+
+external network_listener_start : t -> unit = "ocaml_network_listener_start"
+
+external network_listener_retain : t -> unit = "ocaml_network_listener_retain"
+
+external network_listener_release : t -> unit = "ocaml_network_listener_release"
+
 let create params = network_listener_create params
 
 let create_with_port ~port params =
@@ -18,10 +27,33 @@ let create_with_port ~port params =
 let create_with_connection ~connection params =
   network_listener_create_with_connection connection params
 
-let get_port _ = 1
+let get_port t = network_listener_get_port t
 
 let set_queue ~queue:_ _ = ()
 
-let start _ = ()
+let start t = network_listener_start t
 
 let cancel _ = ()
+
+let retain = network_listener_retain
+
+let release = network_listener_release
+
+module State = struct
+  type t = Invalid | Waiting | Preparing | Ready | Failed | Cancelled
+
+  type handler = t -> Error.t -> unit
+end
+
+external network_listener_set_state_changed_handler : State.handler -> t -> unit
+  = "ocaml_network_listener_set_state_changed_handler"
+
+let set_state_changed_handler ~handler t =
+  network_listener_set_state_changed_handler handler t
+
+external network_listener_set_new_connection_handler :
+  (Connection.t -> unit) -> t -> unit
+  = "ocaml_network_listener_set_new_connection_handler"
+
+let set_new_connection_handler ~handler t =
+  network_listener_set_new_connection_handler handler t

--- a/lib/listener.mli
+++ b/lib/listener.mli
@@ -20,3 +20,17 @@ val start : t -> unit
 
 val cancel : t -> unit
 (** [cancel t] stopos [t] listening for inbound connections *)
+
+val retain : t -> unit
+
+val release : t -> unit
+
+module State : sig
+  type t = Invalid | Waiting | Preparing | Ready | Failed | Cancelled
+
+  type handler = t -> Error.t -> unit
+end
+
+val set_state_changed_handler : handler:State.handler -> t -> unit
+
+val set_new_connection_handler : handler:(Connection.t -> unit) -> t -> unit

--- a/lib/network.ml
+++ b/lib/network.ml
@@ -3,5 +3,4 @@ module Listener = Listener
 module Error = Error
 module Endpoint = Endpoint
 module Parameters = Parameters
-
-let f = Listener.create
+module Connection = Connection

--- a/lib/parameters.ml
+++ b/lib/parameters.ml
@@ -1,9 +1,17 @@
-type t = unit
+type t
 
 external network_parameters_create : unit -> t
   = "ocaml_network_parameters_create"
 
-(* external network_parameters_create_secure_tcp : unit -> t
-  = "ocaml_network_parameters_create" *)
+external network_parameters_create_tcp : unit -> t
+  = "ocaml_network_parameters_create_tcp"
+
+external network_parameters_set_local_endpoint : t -> Endpoint.t -> unit
+  = "ocaml_network_parameters_set_local_endpoint"
 
 let create = network_parameters_create
+
+let create_tcp = network_parameters_create_tcp
+
+let set_local_endpoint ~endpoint t =
+  network_parameters_set_local_endpoint t endpoint

--- a/lib/parameters.mli
+++ b/lib/parameters.mli
@@ -4,3 +4,10 @@ type t
 val create : unit -> t
 (** [create ()] initialises parameters for connections with no protocol
     specified *)
+
+val create_tcp : unit -> t
+(** [create_tcp ()] initialises parameters for connections using tcp without tls *)
+
+val set_local_endpoint : endpoint:Endpoint.t -> t -> unit
+(** [set_local_endpoint ~endpoint t] sets a specifc local IP address and port to
+    use for connections *)

--- a/test/dune
+++ b/test/dune
@@ -1,3 +1,14 @@
 (test
  (name main)
+ (modules main)
  (libraries network))
+
+(executable
+ (name echoer)
+ (modules echoer)
+ (libraries cmdliner logs dispatch network))
+
+(executable
+ (name netcat)
+ (modules netcat)
+ (libraries cmdliner logs dispatch network))

--- a/test/echoer.ml
+++ b/test/echoer.ml
@@ -1,0 +1,15 @@
+let main_queue = Dispatch.Queue.main ()
+
+let stdin_echoer () =
+  (* let group = Dispatch.Group.create () in *)
+  let stdin = Dispatch.Io.create Stream Unix.stdin main_queue in
+  (* Dispatch.Group.enter group; *)
+  Dispatch.Io.with_read ~queue:main_queue ~off:0 ~length:8192
+    ~f:(fun ~err:_ ~finished:_ _data -> print_endline "DATA SENDING")
+    stdin
+
+(* let () = Dispatch.(Group.wait (stdin_echoer ()) @@ Time.forever ()) |> ignore *)
+
+let () =
+  stdin_echoer ();
+  Dispatch.main ()

--- a/test/main.ml
+++ b/test/main.ml
@@ -1,3 +1,6 @@
 open Network
 
-let () = Listener.create (Parameters.create ()) |> ignore
+let () =
+  let listener = Listener.create_with_port ~port:9000 (Parameters.create ()) in
+  Listener.start listener;
+  print_int (Listener.get_port listener)

--- a/test/netcat.ml
+++ b/test/netcat.ml
@@ -1,0 +1,121 @@
+open Network
+
+let main_queue = Dispatch.Queue.main ()
+
+(* Outbound connection *)
+let parameters ?(udp = true) () =
+  if udp then Parameters.create () else Parameters.create_tcp ()
+
+let handler (t : Connection.State.t) _ =
+  match t with
+  | Waiting -> print_endline "Waiting"
+  | Ready -> print_endline "Connection Ready"
+  | _ -> print_endline "Yikes"
+
+let start_connection connection =
+  Connection.set_queue ~queue:main_queue connection;
+  Connection.retain connection;
+  Connection.set_state_changed_handler ~handler connection;
+  Connection.start connection
+
+let outbound hostname port udp =
+  let params = parameters ~udp () in
+  let endpoint = Endpoint.create_host ~hostname port in
+  let connection = Connection.create ~params endpoint in
+  connection
+
+(* Inbound Connections *)
+let g_inbound_connection : Connection.t option ref = ref None
+
+let inbound ?(hostname = "::") ?(port = 0) () =
+  let params = Parameters.create () in
+  let endpoint = Endpoint.create_host ~hostname port in
+  let _ = Parameters.set_local_endpoint ~endpoint params in
+  let _ = Endpoint.release endpoint in
+  params
+
+let start_listener params =
+  let listener = Listener.create params in
+  Listener.set_queue ~queue:main_queue listener;
+  Listener.retain listener;
+  let handler (t : Listener.State.t) _ =
+    match t with Cancelled -> () | _ -> ()
+  in
+  let conn_handler new_connection =
+    match !g_inbound_connection with
+    | None ->
+        Connection.retain new_connection;
+        g_inbound_connection := Some new_connection
+    | Some _ -> Connection.cancel new_connection
+  in
+  Listener.set_state_changed_handler ~handler listener;
+  Listener.set_new_connection_handler ~handler:conn_handler listener;
+  Listener.start listener;
+  listener
+
+(* Receiving & sending *)
+let rec receive connection =
+  let completion data context _is_complete _err =
+    Connection.Context.retain context;
+    let schedule_next_receive =
+      Dispatch.Block.create (fun () -> receive connection)
+    in
+    let stdout = Dispatch.Io.create Stream Unix.stdout main_queue in
+    Dispatch.Io.with_write ~queue:main_queue ~off:0 ~data
+      ~f:(fun ~err:_ ~finished:_ _ -> Dispatch.Block.exec schedule_next_receive)
+      stdout
+  in
+  Connection.receive ~min:1 ~max:max_int ~completion connection
+
+let rec send connection =
+  let stdin = Dispatch.Io.create Stream Unix.stdin main_queue in
+  Dispatch.Io.with_read ~queue:main_queue ~off:0 ~length:max_int
+    ~f:(fun ~err:_ ~finished:_ data ->
+      Connection.send ~is_complete:true
+        ~context:(Connection.Context.default ())
+        ~completion:(fun _ -> send connection)
+        ~data connection)
+    stdin
+
+(* CLI *)
+open Cmdliner
+
+let host =
+  let docv = "HOST" in
+  let doc = "The host to connect to" in
+  Arg.(value & pos 1 string "ocaml.org" & info ~doc ~docv [])
+
+let listen () =
+  let params = inbound ~hostname:"localhost" ~port:8080 () in
+  let _listener = start_listener params in
+  Dispatch.main ()
+
+let listen_info =
+  let doc = "listen" in
+  Term.info ~doc "listen"
+
+let listen_term = (Term.(pure listen $ pure ()), listen_info)
+
+let run host =
+  let conn = outbound host 80 false in
+  let _ = start_connection conn in
+  let _ = send conn in
+  let _ = receive conn in
+  Dispatch.main ()
+
+let connect_info =
+  let doc = "connect" in
+  Term.info ~doc "connect"
+
+let main_term = (Term.(pure run $ host), connect_info)
+
+let cmds = [ main_term; listen_term ]
+
+let doc = "OCaml Netcat"
+
+let main =
+  (Term.ret @@ Term.pure (`Help (`Pager, None)), Term.info "ocaml-nc" ~doc)
+
+let main () = Term.(exit @@ eval_choice main cmds)
+
+let () = main ()


### PR DESCRIPTION
Adds a lot more functionality and starts the implementation of a netcat clone using the guide from https://developer.apple.com/documentation/network/implementing_netcat_with_network_framework

You can try it with: 

```
$ echo -n "GET / HTTP/1.0\r\n\r\n" | _build/default/test/netcat.exe connect
```

It often segfaults but also kinda works :)) 